### PR TITLE
Fix missing .js extension in import statement to resolve asset loading error

### DIFF
--- a/Part1_Chap5/biblios/assets/app.js
+++ b/Part1_Chap5/biblios/assets/app.js
@@ -1,5 +1,5 @@
 import './bootstrap.js';
-import './js/scripts';
+import './js/scripts.js';
 /*
  * Welcome to your app's main JavaScript file!
  *


### PR DESCRIPTION
While rendering the template, an error occurred because the asset ./js/scripts could not be found. This was caused by the missing .js extension in the import statement inside assets/app.js.

This PR fixes the issue by updating the import to :
```js
import './js/scripts.js';
```

This change ensures that the asset is correctly located and loaded, preventing the exception :
```js
An exception has been thrown during the rendering of a template ("Unable to find asset "./js/scripts" imported from "/var/www/html/assets/app.js". Try adding ".js" to the end of the import - i.e. "./js/scripts.js".") in base.html.twig at line 14.

```